### PR TITLE
Artist Track Bugs

### DIFF
--- a/Generators/ArtistGenerator.cs
+++ b/Generators/ArtistGenerator.cs
@@ -7,7 +7,7 @@ namespace MusicDatabaseGenerator.Generators
     public class ArtistGenerator : AGenerator, IGenerator
     {
         private Regex artistNameReg = new Regex("(?<=[\\\\\\/])[^\\\\\\/]*(?= - [^\\\\\\/]* - [^\\\\\\/]*\\.[a-zA-Z]+)", RegexOptions.Compiled);
-        private Regex folderArtistNameReg = new Regex("(?<=[\\\\\\/])[^\\\\\\/]+(?=[\\\\\\/][^\\\\\\/]+[\\\\\\/][^\\\\\\/]+\\.)", RegexOptions.Compiled);
+        private Regex folderArtistNameReg = new Regex("(?<=^[\\\\\\/])[^\\\\\\/]+", RegexOptions.Compiled); //relies on the _inputPath being removed from the file path
         private string _inputPath;
         public ArtistGenerator(TagLib.File file, MusicLibraryTrack data, string inputPath, LoggingUtils logger)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -44,8 +44,7 @@ namespace MusicDatabaseGenerator
                     }
 
                     MusicLibraryTrack.trackIndex += 1;
-                    double averageTrackProcessingTime = sw.Elapsed.TotalMilliseconds / MusicLibraryTrack.trackIndex;
-                    syncManager.Sync(averageTrackProcessingTime * (total - MusicLibraryTrack.trackIndex) / 1000);
+                    syncManager.Sync();
                 }
                 SyncManager.Delete();
                 logger.GenerationLogWriteData($"Inserted {SyncManager.Inserts} record(s)");
@@ -80,8 +79,7 @@ namespace MusicDatabaseGenerator
 
                     MusicLibraryTrack.albumArtIndex += 1;
 
-                    double averageTrackProcessingTime = sw.Elapsed.TotalMilliseconds / MusicLibraryTrack.trackIndex;
-                    syncManager.Sync(averageTrackProcessingTime * (total - MusicLibraryTrack.trackIndex) / 1000);
+                    syncManager.Sync();
                 }
                 SyncManager.Delete();
                 logger.GenerationLogWriteData($"Inserted {SyncManager.Inserts} record(s)");

--- a/Program.cs
+++ b/Program.cs
@@ -44,8 +44,8 @@ namespace MusicDatabaseGenerator
                     }
 
                     MusicLibraryTrack.trackIndex += 1;
-
-                    syncManager.Sync();
+                    double averageTrackProcessingTime = sw.Elapsed.TotalMilliseconds / MusicLibraryTrack.trackIndex;
+                    syncManager.Sync(averageTrackProcessingTime * (total - MusicLibraryTrack.trackIndex) / 1000);
                 }
                 SyncManager.Delete();
                 logger.GenerationLogWriteData($"Inserted {SyncManager.Inserts} record(s)");
@@ -79,8 +79,9 @@ namespace MusicDatabaseGenerator
                     }
 
                     MusicLibraryTrack.albumArtIndex += 1;
-                
-                    syncManager.Sync();
+
+                    double averageTrackProcessingTime = sw.Elapsed.TotalMilliseconds / MusicLibraryTrack.trackIndex;
+                    syncManager.Sync(averageTrackProcessingTime * (total - MusicLibraryTrack.trackIndex) / 1000);
                 }
                 SyncManager.Delete();
                 logger.GenerationLogWriteData($"Inserted {SyncManager.Inserts} record(s)");

--- a/Synchronizers/ArtistTrackSynchronizer.cs
+++ b/Synchronizers/ArtistTrackSynchronizer.cs
@@ -53,7 +53,7 @@ namespace MusicDatabaseGenerator.Synchronizers
 
         public static new SyncOperation Delete()
         {
-            if(_context.ArtistTracks.Where(at => _context.Main.Where(m => m.TrackID == at.TrackID).Any()).Any())
+            if(_context.ArtistTracks.Where(at => !_context.Main.Where(m => m.TrackID == at.TrackID).Any() || !_context.Artist.Where(a => a.ArtistID == at.ArtistID).Any()).Any())
             {
                 _logger.GenerationLogWriteData($"Deleted {_context.ArtistTracks.Where(at => _context.Main.Where(m => m.TrackID == at.TrackID).Any()).Count()} entries from ArtistTracks");
                 _context.ArtistTracks.RemoveRange(_context.ArtistTracks.Where(at => _context.Main.Where(m => m.TrackID == at.TrackID).Any()));

--- a/Synchronizers/SyncManager.cs
+++ b/Synchronizers/SyncManager.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Diagnostics;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace MusicDatabaseGenerator.Synchronizers
 {

--- a/Synchronizers/SyncManager.cs
+++ b/Synchronizers/SyncManager.cs
@@ -33,7 +33,7 @@ namespace MusicDatabaseGenerator.Synchronizers
             _stopwatch.Start();
         }
 
-        public void Sync()
+        public void Sync(double etaSeconds)
         {
             if (albumArtSync)
             {
@@ -55,8 +55,7 @@ namespace MusicDatabaseGenerator.Synchronizers
             }
 
             SyncOperation ops = SyncOperation.None;
-
-            string percentageString = $"{100 * (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) / (decimal)_totalCount:00.00}% | ETA: {(decimal)_stopwatch.ElapsedMilliseconds / (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) * (_totalCount - (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex)) * (decimal)1.0:00.00}sec | ";
+            string percentageString = $"{100 * (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) / (decimal)_totalCount:00.00}% | ETA: {(int)(etaSeconds / 3600):00}:{(int)(etaSeconds % 3600 / 60):00}:{(int)(etaSeconds % 60):00}sec | ";
             using (DbContextTransaction transaction = _context.Database.BeginTransaction())
             {
                 foreach (ISynchronizer synchronizer in _synchronizers)
@@ -79,6 +78,7 @@ namespace MusicDatabaseGenerator.Synchronizers
                 transaction.Commit();
             }
             LogOperation(ops, percentageString);
+            return;
         }
 
         public static void Delete()

--- a/Synchronizers/SyncManager.cs
+++ b/Synchronizers/SyncManager.cs
@@ -24,7 +24,6 @@ namespace MusicDatabaseGenerator.Synchronizers
             _totalCount = count;
             _mlt = mlt;
             albumArtSync = in_albumArtSync;
-            _stopwatch = new Stopwatch();
         }
 
         public void Sync()

--- a/Synchronizers/SyncManager.cs
+++ b/Synchronizers/SyncManager.cs
@@ -15,7 +15,6 @@ namespace MusicDatabaseGenerator.Synchronizers
         private int _totalCount;
         private MusicLibraryTrack _mlt;
         private List<ISynchronizer> _synchronizers = new List<ISynchronizer>();
-        private Stopwatch _stopwatch;
         
         private static bool albumArtSync = false;
         public static int Inserts = 0;
@@ -30,10 +29,9 @@ namespace MusicDatabaseGenerator.Synchronizers
             _mlt = mlt;
             albumArtSync = in_albumArtSync;
             _stopwatch = new Stopwatch();
-            _stopwatch.Start();
         }
 
-        public void Sync(double etaSeconds)
+        public void Sync()
         {
             if (albumArtSync)
             {
@@ -55,7 +53,7 @@ namespace MusicDatabaseGenerator.Synchronizers
             }
 
             SyncOperation ops = SyncOperation.None;
-            string percentageString = $"{100 * (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) / (decimal)_totalCount:00.00}% | ETA: {(int)(etaSeconds / 3600):00}:{(int)(etaSeconds % 3600 / 60):00}:{(int)(etaSeconds % 60):00}sec | ";
+            string percentageString = $"{100 * (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) / (decimal)_totalCount:00.00}% | ";
             using (DbContextTransaction transaction = _context.Database.BeginTransaction())
             {
                 foreach (ISynchronizer synchronizer in _synchronizers)
@@ -78,7 +76,6 @@ namespace MusicDatabaseGenerator.Synchronizers
                 transaction.Commit();
             }
             LogOperation(ops, percentageString);
-            return;
         }
 
         public static void Delete()


### PR DESCRIPTION
All artist tracks were being deleted because of a missing `!`. Also, it wasn't considering if the artist track should be deleted because of the missing artist entry. The folder regex usually was not used during generation, but was subpar and improved.

An ETA system was attempted, but in hindsight, this is not super useful and very difficult to predict accurately. Other features are more important at this time.