### PR TITLE
Sanitize ISRCs to Reduce Type Overflows

### DIFF
--- a/Generators/MainGenerator.cs
+++ b/Generators/MainGenerator.cs
@@ -38,7 +38,7 @@ namespace MusicDatabaseGenerator.Generators
                 BeatsPerMin = (int)_file.Tag.BeatsPerMinute,
                 Copyright = _file.Tag.Copyright,
                 Publisher = _file.Tag.Publisher,
-                ISRC = _file.Tag.ISRC ?? "",
+                ISRC = (_file.Tag.ISRC ?? "").Replace("-", ""), //some ISRCs are in the format A1-B2C-3D4-E5F6
                 Bitrate = _file.Properties.AudioBitrate,
                 Channels = _file.Properties.AudioChannels,
                 SampleRate = _file.Properties.AudioSampleRate,

--- a/Synchronizers/SyncManager.cs
+++ b/Synchronizers/SyncManager.cs
@@ -48,7 +48,7 @@ namespace MusicDatabaseGenerator.Synchronizers
             }
 
             SyncOperation ops = SyncOperation.None;
-            string percentageString = $"{100 * (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) / (decimal)_totalCount:00.00}% | ";
+            string percentageString = $"{100 * (albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex) / (decimal)_totalCount:00.00}% |";
             using (DbContextTransaction transaction = _context.Database.BeginTransaction())
             {
                 foreach (ISynchronizer synchronizer in _synchronizers)


### PR DESCRIPTION
ISRCs are 12-character codes that act as the ID for a musical track, independent of media form. It's like the ISBN of music. Some ISRCs have hyphens in them. Rather than just increasing the size of the ISRC field in the database, we remove the hyphens. This way all ISRCs are stored in the same format in the database.

Future changes will simply ignore invalid data (while logging that fact to the generation logs) instead of halting execution of the program completely.