### PR TITLE
Use Milliseconds for Duration Instead of Seconds; Re-Add Generated Date

### DIFF
--- a/MusicDatabaseGenerator/Generators/MainGenerator.cs
+++ b/MusicDatabaseGenerator/Generators/MainGenerator.cs
@@ -32,6 +32,7 @@ namespace MusicDatabaseGenerator.Generators
                 Duration = PVU.PrevalidateDoubleToDecimalCast(Math.Round(_file.Properties.Duration.TotalSeconds), nameof(Main.Duration)),
                 ReleaseYear = (int?)PVU.PrevalidateUnsignedIntToIntCast(_file.Tag.Year, nameof(Main.ReleaseYear)) == 0 ? null : (int?)PVU.PrevalidateUnsignedIntToIntCast(_file.Tag.Year, nameof(Main.ReleaseYear)),
                 AddDate = new FileInfo(_file.Name).CreationTime,
+                GeneratedDate = DateTime.Now,
                 LastModifiedDate = new FileInfo(_file.Name).LastWriteTime,
                 Lyrics = PVU.PrevalidateStringTruncate(_file.Tag.Lyrics, 4000, nameof(Main.Lyrics)),
                 Comment = PVU.PrevalidateStringTruncate(_file.Tag.Comment, 4000, nameof(Main.Comment)),

--- a/MusicDatabaseGenerator/Generators/MainGenerator.cs
+++ b/MusicDatabaseGenerator/Generators/MainGenerator.cs
@@ -29,7 +29,7 @@ namespace MusicDatabaseGenerator.Generators
             {
                 Title = PVU.PrevalidateStringTruncate(title, 435, nameof(Main.Title)),
                 FilePath = PVU.PrevalidateStringTruncate(Path.GetFullPath(_file.Name), 260, nameof(Main.FilePath)),
-                Duration = PVU.PrevalidateDoubleToDecimalCast(Math.Round(_file.Properties.Duration.TotalSeconds), nameof(Main.Duration)),
+                Duration = PVU.PrevalidateDoubleToDecimalCast(Math.Round(_file.Properties.Duration.TotalMilliseconds), nameof(Main.Duration)),
                 ReleaseYear = (int?)PVU.PrevalidateUnsignedIntToIntCast(_file.Tag.Year, nameof(Main.ReleaseYear)) == 0 ? null : (int?)PVU.PrevalidateUnsignedIntToIntCast(_file.Tag.Year, nameof(Main.ReleaseYear)),
                 AddDate = new FileInfo(_file.Name).CreationTime,
                 GeneratedDate = DateTime.Now,

--- a/MusicDatabaseGenerator/Schema/SCHEMA_README.md
+++ b/MusicDatabaseGenerator/Schema/SCHEMA_README.md
@@ -4,7 +4,7 @@ This table stores metadata that relates directly to 1 track
   - Use this ID to map songs in other tables. These values are unique across all tables that reference this ID.
 - `Title`
 - `Duration`
-  - The duration of the song in seconds
+  - The duration of the song in milliseconds. Stored in milliseconds to avoid tollerance stacking when calculating the duration of playlists.
 - `FilePath`
   - The file path of the song, based on where you tell the source code to look for your files
 - `Volume`


### PR DESCRIPTION
- Now using milliseconds for duration units (to match how most music apps store duration)
  - There is no migration for this change unfortunately since we have already truncated the data by rounding to the nearest second
  - TODO: Explained in the Readme
- The generated date was missing and was never set. It is now present.