### PR TITLE
Un-Hide Album Art During Processing

### DIFF
--- a/MusicDatabaseGenerator/Generators/AlbumArtGenerator.cs
+++ b/MusicDatabaseGenerator/Generators/AlbumArtGenerator.cs
@@ -22,6 +22,8 @@ namespace MusicDatabaseGenerator.Generators
 
         public void Generate()
         {
+            UnhideAlbumArtImages(_imgFileName);
+
             _data.albumArt = new AlbumArt()
             {
                 AlbumArtPath = PVU.PrevalidateStringTruncate(Path.GetFullPath(_imgFileName), 260, nameof(AlbumArt.AlbumArtPath)),
@@ -75,5 +77,26 @@ namespace MusicDatabaseGenerator.Generators
             string b = color.B.ToString("X2");
             return $"#{r}{g}{b}";
         }
+
+        private void UnhideAlbumArtImages(string path)
+        {
+            if (File.GetAttributes(path).HasFlag(FileAttributes.Hidden))
+            {
+                File.SetAttributes(path, FileAttributes.Normal);
+            }
+        }
+
+        /*private void TEMP_ExportImages(string path)
+        {
+            string sanitizedPath = path.Replace('\\', '/');
+            string relativePath = sanitizedPath.Substring(sanitizedPath.IndexOf("/Music/"));
+            string fullPath = $"F:/MyMusicImageData_TEMP{relativePath}";
+            string folder = fullPath.Substring(0, fullPath.LastIndexOf("/"));
+            if(!Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+            File.Copy(path, fullPath);
+        }*/
     }
 }


### PR DESCRIPTION
Originally, we were going to "extract" the image data and re-save them as a separate file, but I realized that I could just un-hide the ones that Windows automatically generates from the embedded data on the mp3 files. This means that there were no updates to what is in the database, just what files you should be copying around to your devices

Background:
- MP3 files can store embedded images inside of them
- Windows automatically generates hidden versions of these files directly accessible via the file system (if you know the path)
- Other OSes (android specifically) does not generate the same kind of hidden files, and though the data for the images is still contained in the MP3, the way of reading that data would require a plugin or direct byte manipulation
  - As a short term solution (since this entire system will likely move to be on-device), we can use the same Windows paths in Android if we just copy the unhidden image files over to Android