### PR TITLE
Export Album Art and Newly Imported Files to Specific Directory

### DIFF
--- a/MusicDatabaseGenerator/App.config
+++ b/MusicDatabaseGenerator/App.config
@@ -5,7 +5,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
-  <connectionStrings configSource="sqlite.config">
+  <connectionStrings configSource="mssql.config">
   </connectionStrings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />

--- a/MusicDatabaseGenerator/Configurator.cs
+++ b/MusicDatabaseGenerator/Configurator.cs
@@ -15,15 +15,20 @@ namespace MusicDatabaseGenerator
         public bool generateMusicMetadata { get; private set; }
         public bool deleteExistingData { get; private set; }
         public bool runMigrations { get; private set; }
+        public string trackOutputPath { get; private set; }
+        public string imageOutputPath { get; private set; }
         public DatabaseProvider databaseProvider { get; private set; }
 
-        public ConfiguratorValues(string pathToSearch, bool generateAlbumArtData, bool generateMusicMetadata, bool deleteExistingData, bool runMigrations, DatabaseProvider dbProvider)
+
+        public ConfiguratorValues(string pathToSearch, bool generateAlbumArtData, bool generateMusicMetadata, bool deleteExistingData, bool runMigrations, string trackOutputPath, string imageOutputPath, DatabaseProvider dbProvider)
         {
             this.pathToSearch = pathToSearch;
             this.generateAlbumArtData = generateAlbumArtData;
             this.generateMusicMetadata = generateMusicMetadata;
             this.deleteExistingData = deleteExistingData;
             this.runMigrations = runMigrations;
+            this.trackOutputPath = trackOutputPath;
+            this.imageOutputPath = imageOutputPath;
             databaseProvider = dbProvider;
         }
     }
@@ -60,6 +65,8 @@ namespace MusicDatabaseGenerator
                 settings["GenerateMusicMetadata"] == "True",
                 settings["DeleteDataOnGeneration"] == "True",
                 settings["RunMigrations"] == "True",
+                settings["NewTrackOutputPath"],
+                settings["AlbumArtOutputPath"],
                 /*BUILD_PROCESS_SQLite: INACTIVE
                  DatabaseProvider.SQLite
                  /**/

--- a/MusicDatabaseGenerator/Configurator.cs
+++ b/MusicDatabaseGenerator/Configurator.cs
@@ -15,18 +15,20 @@ namespace MusicDatabaseGenerator
         public bool generateMusicMetadata { get; private set; }
         public bool deleteExistingData { get; private set; }
         public bool runMigrations { get; private set; }
+        public bool unhideHiddenAlbumArt { get; private set; }
         public string trackOutputPath { get; private set; }
         public string imageOutputPath { get; private set; }
         public DatabaseProvider databaseProvider { get; private set; }
 
 
-        public ConfiguratorValues(string pathToSearch, bool generateAlbumArtData, bool generateMusicMetadata, bool deleteExistingData, bool runMigrations, string trackOutputPath, string imageOutputPath, DatabaseProvider dbProvider)
+        public ConfiguratorValues(string pathToSearch, bool generateAlbumArtData, bool generateMusicMetadata, bool deleteExistingData, bool runMigrations, bool unhideHiddenAlbumArt, string trackOutputPath, string imageOutputPath, DatabaseProvider dbProvider)
         {
             this.pathToSearch = pathToSearch;
             this.generateAlbumArtData = generateAlbumArtData;
             this.generateMusicMetadata = generateMusicMetadata;
             this.deleteExistingData = deleteExistingData;
             this.runMigrations = runMigrations;
+            this.unhideHiddenAlbumArt = unhideHiddenAlbumArt;
             this.trackOutputPath = trackOutputPath;
             this.imageOutputPath = imageOutputPath;
             databaseProvider = dbProvider;
@@ -65,6 +67,7 @@ namespace MusicDatabaseGenerator
                 settings["GenerateMusicMetadata"] == "True",
                 settings["DeleteDataOnGeneration"] == "True",
                 settings["RunMigrations"] == "True",
+                settings["UnhideHiddenAlbumArtFiles"] == "True",
                 settings["NewTrackOutputPath"],
                 settings["AlbumArtOutputPath"],
                 /*BUILD_PROCESS_SQLite: INACTIVE
@@ -95,6 +98,9 @@ namespace MusicDatabaseGenerator
             }
 
             _logger.GenerationLogWriteData($"Searching for data at location \"{values.pathToSearch}\"");
+            if(!string.IsNullOrWhiteSpace(values.trackOutputPath)) _logger.GenerationLogWriteData($"Will export newly ingested tracks to \"{values.trackOutputPath}\"");
+            if(!string.IsNullOrWhiteSpace(values.imageOutputPath)) _logger.GenerationLogWriteData($"Will export all album art files \"{values.imageOutputPath}\"");
+            _logger.GenerationLogWriteData($"Will {(values.unhideHiddenAlbumArt ? "" : "NOT ")}unhide album art files extracted from MP3 files.");
             _logger.GenerationLogWriteData($@"{(values.generateAlbumArtData ?
                 values.generateMusicMetadata ?
                     "Will generate music metadata and album art metadata"

--- a/MusicDatabaseGenerator/FileOutputService.cs
+++ b/MusicDatabaseGenerator/FileOutputService.cs
@@ -1,0 +1,120 @@
+﻿using MusicDatabaseGenerator.Synchronizers;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace MusicDatabaseGenerator
+{
+    public class FileOutputService
+    {
+        private List<string> _tracksToOutput = new List<string>();
+        private List<string> _imagesToOutput = new List<string>();
+
+        private string _trackOutputPath;
+        private string _imageOutputPath;
+        private string _relativeToPath;
+        private LoggingUtils _logger;
+
+        private readonly Regex _afterRelativePathRegex;
+
+        public FileOutputService(ConfiguratorValues config, LoggingUtils logger)
+        {
+            _trackOutputPath = config.trackOutputPath;
+            _imageOutputPath = config.imageOutputPath;
+            var sanitizedPathToSearch = config.pathToSearch.Replace("\\", "/");
+            _relativeToPath = sanitizedPathToSearch.Substring(sanitizedPathToSearch.LastIndexOf("/") + 1);
+            _relativeToPath = string.IsNullOrWhiteSpace(_relativeToPath) ? "Music" : _relativeToPath;
+            _afterRelativePathRegex = new Regex($@"(?<={_relativeToPath.Replace("/", "")}[\\/]).+", RegexOptions.Compiled);
+            _logger = logger;
+        }
+
+        public void LoadSynchronizedTrack(SyncOperation op, string trackPath)
+        {
+            if(!string.IsNullOrWhiteSpace(_trackOutputPath))
+            {
+                if ((op & SyncOperation.Insert) > 0 || (op & SyncOperation.Update) > 0)
+                {
+                    _tracksToOutput.Add(trackPath);
+                }
+            }
+        }
+
+        public void LoadSynchronizedImage(SyncOperation op, string imagePath)
+        {
+            if(!string.IsNullOrWhiteSpace(_imageOutputPath))
+            {
+                if ((op & SyncOperation.Insert) > 0 || (op & SyncOperation.Update) > 0)
+                {
+                    _tracksToOutput.Add(imagePath);
+                }
+            }
+        }
+
+        public void Export()
+        {
+            if(!string.IsNullOrWhiteSpace(_trackOutputPath))
+            {
+                _logger.GenerationLogWriteData($"Exporting tracks with directory structure to {_trackOutputPath}");
+                ExportTracks();
+            }
+            if(!string.IsNullOrWhiteSpace(_imageOutputPath))
+            {
+                _logger.GenerationLogWriteData($"Exporting images with directory structure to {_imageOutputPath}");
+                ExportImages();
+            }
+        }
+
+        private void ExportImages()
+        {
+            foreach (var imagePath in _imagesToOutput)
+            {
+                var relativeMatch = _afterRelativePathRegex.Match(imagePath);
+                if (relativeMatch.Success)
+                {
+                    var writePath = Path.Combine(_imageOutputPath, relativeMatch.Value);
+                    writePath = writePath.Replace("\\", "/");
+                    string folder = writePath.Substring(0, writePath.LastIndexOf("/"));
+                    if (!Directory.Exists(folder))
+                    {
+                        Directory.CreateDirectory(folder);
+                    }
+                    if(File.Exists(writePath))
+                    {
+                        File.Delete(writePath); //overwrite existing files, but merge updates otherwise
+                    }
+                    File.Copy(imagePath, writePath);
+                }
+                else
+                {
+                    _logger.GenerationLogWriteData($"WARNING: Image path \"{imagePath}\" did not seem to be contained in the directory \"{_relativeToPath}\"");
+                }
+            }
+        }
+
+        private void ExportTracks()
+        {
+            foreach(var trackPath in _tracksToOutput)
+            {
+                var relativeMatch = _afterRelativePathRegex.Match(trackPath);
+                if(relativeMatch.Success)
+                {
+                    var writePath = Path.Combine(_trackOutputPath, relativeMatch.Value);
+                    writePath = writePath.Replace("\\", "/");
+                    string folder = writePath.Substring(0, writePath.LastIndexOf("/"));
+                    if (!Directory.Exists(folder))
+                    {
+                        Directory.CreateDirectory(folder);
+                    }
+                    if (File.Exists(writePath))
+                    {
+                        File.Delete(writePath); //overwrite existing files, but merge updates otherwise
+                    }
+                    File.Copy(trackPath, writePath);
+                } else
+                {
+                    _logger.GenerationLogWriteData($"WARNING: Track path \"{trackPath}\" did not seem to be contained in the directory \"{_relativeToPath}\"");
+                }
+            }
+        }
+    }
+}

--- a/MusicDatabaseGenerator/FileOutputService.cs
+++ b/MusicDatabaseGenerator/FileOutputService.cs
@@ -39,14 +39,11 @@ namespace MusicDatabaseGenerator
             }
         }
 
-        public void LoadSynchronizedImage(SyncOperation op, string imagePath)
+        public void LoadSynchronizedImage(string imagePath)
         {
             if(!string.IsNullOrWhiteSpace(_imageOutputPath))
             {
-                if ((op & SyncOperation.Insert) > 0 || (op & SyncOperation.Update) > 0)
-                {
-                    _tracksToOutput.Add(imagePath);
-                }
+                _imagesToOutput.Add(imagePath);
             }
         }
 

--- a/MusicDatabaseGenerator/Generators/AlbumArtGenerator.cs
+++ b/MusicDatabaseGenerator/Generators/AlbumArtGenerator.cs
@@ -86,18 +86,5 @@ namespace MusicDatabaseGenerator.Generators
                 File.SetAttributes(path, FileAttributes.Normal);
             }
         }
-
-        /*private void TEMP_ExportImages(string path)
-        {
-            string sanitizedPath = path.Replace('\\', '/');
-            string relativePath = sanitizedPath.Substring(sanitizedPath.IndexOf("/Music/"));
-            string fullPath = $"F:/MyMusicImageData_TEMP{relativePath}";
-            string folder = fullPath.Substring(0, fullPath.LastIndexOf("/"));
-            if(!Directory.Exists(folder))
-            {
-                Directory.CreateDirectory(folder);
-            }
-            File.Copy(path, fullPath);
-        }*/
     }
 }

--- a/MusicDatabaseGenerator/Generators/AlbumArtGenerator.cs
+++ b/MusicDatabaseGenerator/Generators/AlbumArtGenerator.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace MusicDatabaseGenerator.Generators
 {
@@ -13,16 +9,21 @@ namespace MusicDatabaseGenerator.Generators
     {
         private Bitmap _imgFile;
         private string _imgFileName;
-        public AlbumArtGenerator(Bitmap imgFile, string imgFileName, MusicLibraryTrack track)
+        private bool _unhideHiddenAlbumArt;
+        public AlbumArtGenerator(Bitmap imgFile, string imgFileName, MusicLibraryTrack track, ConfiguratorValues config)
         {
             _imgFile = imgFile;
             _data = track;
             _imgFileName = imgFileName;
+            _unhideHiddenAlbumArt = config.unhideHiddenAlbumArt;
         }
 
         public void Generate()
         {
-            UnhideAlbumArtImages(_imgFileName);
+            if(_unhideHiddenAlbumArt)
+            {
+                UnhideAlbumArtImages(_imgFileName);
+            }
 
             _data.albumArt = new AlbumArt()
             {

--- a/MusicDatabaseGenerator/MusicDatabaseGenerator.csproj
+++ b/MusicDatabaseGenerator/MusicDatabaseGenerator.csproj
@@ -152,6 +152,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FileOutputService.cs" />
     <Compile Include="Models\Album.cs" />
     <Compile Include="Models\AlbumArt.cs" />
     <Compile Include="Models\AlbumTracks.cs" />

--- a/MusicDatabaseGenerator/Program.cs
+++ b/MusicDatabaseGenerator/Program.cs
@@ -84,7 +84,8 @@ namespace MusicDatabaseGenerator
 
                     MusicLibraryTrack.albumArtIndex += 1;
 
-                    exportService.LoadSynchronizedImage(syncManager.Sync(), img.Item1);
+                    syncManager.Sync();
+                    exportService.LoadSynchronizedImage(img.Item1);
                 }
                 SyncManager.Delete();
                 logger.GenerationLogWriteData($"Inserted {SyncManager.Inserts} record(s)");
@@ -92,6 +93,8 @@ namespace MusicDatabaseGenerator
                 logger.GenerationLogWriteData($"Skipped {SyncManager.Skips} record(s)");
                 logger.GenerationLogWriteComment($"Album Art Data Inserted Into Database in {sw.Elapsed.TotalSeconds} seconds");
             }
+
+            exportService.Export();
 
             logger.GenerationLogWriteData("Music Database Generator completed successfully.");
 

--- a/MusicDatabaseGenerator/Program.cs
+++ b/MusicDatabaseGenerator/Program.cs
@@ -20,6 +20,9 @@ namespace MusicDatabaseGenerator
 
             FolderReader.InjectDependencies(logger);
             (List<TagLib.File> tagFiles, List<(string, Bitmap)> coverArt) constructedTuple = FolderReader.ReadToTagLibFiles(config.pathToSearch, true);
+
+            FileOutputService exportService = new FileOutputService(config, logger);
+
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
@@ -45,7 +48,7 @@ namespace MusicDatabaseGenerator
                     }
 
                     MusicLibraryTrack.trackIndex += 1;
-                    syncManager.Sync();
+                    exportService.LoadSynchronizedTrack(syncManager.Sync(), trackData.main.FilePath);
                 }
                 new PostProcessingSynchronizer(mdbContext).Synchronize(); //external for performance reasons
                 SyncManager.Delete();
@@ -81,7 +84,7 @@ namespace MusicDatabaseGenerator
 
                     MusicLibraryTrack.albumArtIndex += 1;
 
-                    syncManager.Sync();
+                    exportService.LoadSynchronizedImage(syncManager.Sync(), img.Item1);
                 }
                 SyncManager.Delete();
                 logger.GenerationLogWriteData($"Inserted {SyncManager.Inserts} record(s)");

--- a/MusicDatabaseGenerator/Program.cs
+++ b/MusicDatabaseGenerator/Program.cs
@@ -74,7 +74,7 @@ namespace MusicDatabaseGenerator
 
                     List<IGenerator> generators = new List<IGenerator>
                     {
-                        new AlbumArtGenerator(img.Item2, img.Item1, trackData),
+                        new AlbumArtGenerator(img.Item2, img.Item1, trackData, config),
                     };
 
                     foreach (IGenerator generator in generators)

--- a/MusicDatabaseGenerator/Synchronizers/MainSynchonizer.cs
+++ b/MusicDatabaseGenerator/Synchronizers/MainSynchonizer.cs
@@ -55,10 +55,6 @@ namespace MusicDatabaseGenerator.Synchronizers
             Main match = _context.Main.First(m => m.ISRC == _mlt.main.ISRC && m.Duration == _mlt.main.Duration && m.Title == _mlt.main.Title);
             _mlt.main.TrackID = match.TrackID; //maintain ID so other mappings remain sound
             _idsSeen.Add(match.TrackID);
-            if(match.Title == "Fade Out")
-            {
-                Console.WriteLine("Test case");
-            }
             if (SQLCSharpDateTimeComparison(match.LastModifiedDate, _mlt.main.LastModifiedDate) <= 0)
             {
                 match.GeneratedDate = _mlt.main.GeneratedDate;

--- a/MusicDatabaseGenerator/Synchronizers/SyncManager.cs
+++ b/MusicDatabaseGenerator/Synchronizers/SyncManager.cs
@@ -26,7 +26,7 @@ namespace MusicDatabaseGenerator.Synchronizers
             albumArtSync = in_albumArtSync;
         }
 
-        public void Sync()
+        public SyncOperation Sync()
         {
             if (albumArtSync)
             {
@@ -62,12 +62,13 @@ namespace MusicDatabaseGenerator.Synchronizers
                         {
                             _logger.GenerationLogWriteData($"{percentageString} Finished processing track {(albumArtSync ? MusicLibraryTrack.albumArtIndex : MusicLibraryTrack.trackIndex)} (skipped) ({_mlt.main.Title})");
                         }
-                        return; //skip the title
+                        return ops; //skip the title
                     }
                 }
                 transaction.Commit();
             }
             LogOperation(ops, percentageString);
+            return ops;
         }
 
         public static void Delete()

--- a/MusicDatabaseGenerator/appsettings.json
+++ b/MusicDatabaseGenerator/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
 	"Settings": {
-		"MusicFolderPathAbsolute": "C:/Users/jeff1/Music",
+		"MusicFolderPathAbsolute": "C:/Users/username/Music",
 		"RunMigrations": false,
 		"GenerateAlbumArtData": true,
 		"GenerateMusicMetadata": true,

--- a/MusicDatabaseGenerator/appsettings.json
+++ b/MusicDatabaseGenerator/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
 	"Settings": {
-		"MusicFolderPathAbsolute": "C:/Users/username/Music",
+		"MusicFolderPathAbsolute": "C:/Users/jeff1/Music",
 		"RunMigrations": false,
 		"GenerateAlbumArtData": true,
 		"GenerateMusicMetadata": true,

--- a/MusicDatabaseGenerator/appsettings.json
+++ b/MusicDatabaseGenerator/appsettings.json
@@ -5,6 +5,7 @@
 		"GenerateAlbumArtData": true,
 		"GenerateMusicMetadata": true,
 		"DeleteDataOnGeneration": false,
+		"UnhideHiddenAlbumArtFiles": false,
 		"NewTrackOutputPath": ""/*"..\\..\\NewTracks"*/,
 		"AlbumArtOutputPath": ""/*"..\\..\\AllAlbumArt"*/
 	}

--- a/MusicDatabaseGenerator/appsettings.json
+++ b/MusicDatabaseGenerator/appsettings.json
@@ -5,7 +5,7 @@
 		"GenerateAlbumArtData": true,
 		"GenerateMusicMetadata": true,
 		"DeleteDataOnGeneration": false,
-		"NewTrackOutputPath": "..\\..\\NewTracks",
-		"AlbumArtOutputPath": "..\\..\\AllAlbumArt"
+		"NewTrackOutputPath": ""/*"..\\..\\NewTracks"*/,
+		"AlbumArtOutputPath": ""/*"..\\..\\AllAlbumArt"*/
 	}
 }

--- a/MusicDatabaseGenerator/appsettings.json
+++ b/MusicDatabaseGenerator/appsettings.json
@@ -4,6 +4,8 @@
 		"RunMigrations": false,
 		"GenerateAlbumArtData": true,
 		"GenerateMusicMetadata": true,
-		"DeleteDataOnGeneration": false
+		"DeleteDataOnGeneration": false,
+		"NewTrackOutputPath": "..\\..\\NewTracks",
+		"AlbumArtOutputPath": "..\\..\\AllAlbumArt"
 	}
 }


### PR DESCRIPTION
Users can now add a path to export any new music files they've added since the last run, which can be useful for synchronizing those changes to other devices or determining differences between 2 users' music collections.
- The default for this config is that it will not export, opt in to the functionality by adding a valid absolute or relative path to the `NewTrackOutputPath` config

Users can choose to unhide album art images, rather than that being the default.
- Set `UnhideHiddenAlbumArtFiles` to `true` to opt back in to this behavior

Users can also add a path to export all image metadata that is currently unhidden from the user. Since image metadata is usually small and easy to copy around, we always export all images.
- The default for this config is that it will not export, opt in to the functionality by adding a valid absolute or relative path to the `AlbumArtOutputPath` config